### PR TITLE
Fix help message

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,15 @@ Warning: if you're not using a release build, **use a release build**
 ## Usage:
 
 ```
-Usage: proton-all VERSION PROGRAM
+Usage: proton-call VERSION PROGRAM
    or: basename OPTION PATH PROGRAM
 Execute PROGRAM with Proton VERSION
 If specified, run proton PATH
 
-  -c, --custom PATH   use proton from PATH
-  --help              display this help message
-  --version           display version information
+  -c, --custom PATH       use proton from PATH
+  -h, --help              display this help message
+  -s, --setup             display setup information
+  -v, --version           display version information
 ```
 
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,10 +47,10 @@ fn help() {
     println!("   or: basename OPTION PATH PROGRAM");
     println!("Execute PROGRAM with Proton VERSION");
     println!("If specified, run proton PATH\n");
-    println!("  -c, --custom PATH   use proton from PATH");
+    println!("  -c, --custom PATH       use proton from PATH");
     println!("  -h, --help              display this help message");
+    println!("  -s, --setup             display setup information");
     println!("  -v, --version           display version information");
-    println!("  -s --setup             display setup information");
 }
 
 fn pc_version() {


### PR DESCRIPTION
- README: `proton-all` -> `proton-call`
- README: Add short options and `--setup`
- Sort options alphabetically
- Add forgotten comma after `-s`
- Align `-c` with rest of the options