### PR TITLE
Assign common from common, not steam

### DIFF
--- a/src/bin/proton-call.rs
+++ b/src/bin/proton-call.rs
@@ -60,7 +60,7 @@ impl Caller {
         let config: HashMap<String, String> = toml::from_str(&config_dat)?;
 
         let common: Option<String> = if config.contains_key("common") {
-            Some(config["steam"].clone())
+            Some(config["common"].clone())
         } else {
             None
         };


### PR DESCRIPTION
Currently, using `common` in the config makes an error like `error: /home/chris/.steam/steam//Proton 5.13/proton not found!`