### PR TITLE
Use HashMap instead of BtreeMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "jargon-args"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f822f93441a0df2080a5ca60d861b4cf4ea53e65dccddbe04a70e6630f9e8341"
+checksum = "e1e1a4272819cbb3e7d0290885b457d2f2df46dbc9c4f4511ef83797c7f688a7"
 
 [[package]]
 name = "lliw"
@@ -54,18 +54,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "jargon-args"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,6 +36,7 @@ dependencies = [
 name = "proton-call"
 version = "3.0.1"
 dependencies = [
+ "bincode",
  "jargon-args",
  "lliw",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ toml = "0.5"
 jargon-args = "0.2.3"
 lliw = "0.2.0"
 serde = { version = "1", features = ["derive"] }
+bincode = "1.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ lto = true
 codegen-units = 1
 
 [dependencies]
-toml = "0.5"
-jargon-args = "0.2.3"
+toml = "0.5.8"
+jargon-args = "0.2.5"
 lliw = "0.2.0"
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1.0.132", features = ["derive"] }
 bincode = "1.3.3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,6 @@
+extern crate serde;
+extern crate toml;
+
 use crate::{
     error::{Error, Kind},
     throw,

--- a/src/index.rs
+++ b/src/index.rs
@@ -2,15 +2,16 @@ use crate::error::{Error, Kind};
 use crate::{pass, throw, Version};
 use lliw::Fg::LightYellow as Yellow;
 use lliw::Reset;
-use std::collections::BTreeMap;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fmt::{Display, Formatter};
-use std::fs::DirEntry;
+use std::fs::{DirEntry, OpenOptions};
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 /// Index type to Index Proton versions in common
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Index {
     dir: PathBuf,
     inner: HashMap<Version, PathBuf>,
@@ -25,7 +26,7 @@ impl Display for Index {
         );
 
         for (version, path) in &self.inner {
-            str = format!("{}\nProton {} `{}`", str, version, path.display());
+            str = format!("{}\nProton {}: {}", str, version, path.display());
         }
 
         write!(f, "{}", str)
@@ -44,31 +45,92 @@ impl Index {
             inner: HashMap::new(),
         };
 
-        idx.index()?;
-
+        idx.load()?;
         Ok(idx)
     }
 
     #[must_use]
+    #[inline]
     /// Returns the number of Indexed Protons
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
     #[must_use]
+    #[inline]
     /// Returns true if Index is empty
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 
     #[must_use]
+    #[inline]
     /// Retrieves the path of the requested Proton version
-    pub fn get(&self, version: &Version) -> Option<&PathBuf> {
-        self.inner.get(version)
+    pub fn get(&self, version: &Version) -> Option<PathBuf> {
+        self.inner.get(version).map(std::clone::Clone::clone)
+    }
+
+    fn cache_location() -> Result<PathBuf, Error> {
+        use std::env::var;
+
+        if let Ok(val) = var("HOME") {
+            let path = format!("{}/.cache/proton/index", val);
+            Ok(PathBuf::from(path))
+        } else {
+            throw!(Kind::Environment, "XDG_CONFIG_HOME / HOME missing")
+        }
+    }
+
+    fn load(&mut self) -> Result<(), Error> {
+        if let Ok(path) = Self::cache_location() {
+            if let Ok(mut file) = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .read(true)
+                .open(path)
+            {
+                let mut buf: Vec<u8> = Vec::new();
+                if file.read_to_end(&mut buf).is_ok() {
+                    if let Ok(index) = bincode::deserialize::<Self>(&buf) {
+                        self.dir = index.dir;
+                        self.inner = index.inner;
+                        return Ok(());
+                    }
+                }
+            }
+        }
+
+        eprintln!("{}warning:{} failed to load index… reindexing...", Yellow, Reset);
+
+        self.index()?;
+        self.save();
+
+        Ok(())
+    }
+
+    fn save(&self) {
+        if let Ok(path) = Self::cache_location() {
+            if let Ok(mut file) = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .read(true)
+                .open(path)
+            {
+                if let Ok(index) = bincode::serialize(self) {
+                    if file.write(&index).is_err() {
+                        eprintln!("{}warning:{} failed writing to cached index", Yellow, Reset);
+                    }
+                }
+            }
+        }
+
+        eprintln!("{}warning:{} failed opening cached index", Yellow, Reset);
     }
 
     /// Indexes Proton versions
-    fn index(&mut self) -> Result<(), Error> {
+    /// # Errors
+    /// An error is returned when the function cannot read the common directory
+    pub fn index(&mut self) -> Result<(), Error> {
         if let Ok(rd) = self.dir.read_dir() {
             for result_entry in rd {
                 let entry: DirEntry = if let Ok(e) = result_entry {

--- a/src/index.rs
+++ b/src/index.rs
@@ -3,6 +3,7 @@ use crate::{pass, throw, Version};
 use lliw::Fg::LightYellow as Yellow;
 use lliw::Reset;
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fmt::{Display, Formatter};
 use std::fs::DirEntry;
@@ -12,7 +13,7 @@ use std::path::{Path, PathBuf};
 #[derive(Debug)]
 pub struct Index {
     dir: PathBuf,
-    inner: BTreeMap<Version, PathBuf>,
+    inner: HashMap<Version, PathBuf>,
 }
 
 impl Display for Index {
@@ -40,7 +41,7 @@ impl Index {
     pub fn new(index: &Path) -> Result<Index, Error> {
         let mut idx = Index {
             dir: index.to_path_buf(),
-            inner: BTreeMap::new(),
+            inner: HashMap::new(),
         };
 
         idx.index()?;
@@ -62,9 +63,8 @@ impl Index {
 
     #[must_use]
     /// Retrieves the path of the requested Proton version
-    pub fn get(&self, version: Version) -> Option<PathBuf> {
-        let path = self.inner.get(&version)?;
-        Some(path.clone())
+    pub fn get(&self, version: &Version) -> Option<&PathBuf> {
+        self.inner.get(version)
     }
 
     /// Indexes Proton versions

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,9 @@ proton-call -c '/path/to/Proton version' -r foo.exe
 ```
  */
 
+extern crate jargon_args;
+extern crate lliw;
+
 use proton_call::error::{Error, Kind};
 use proton_call::{pass, throw, Config, Index, Proton, Version};
 use std::path::PathBuf;
@@ -105,8 +108,8 @@ fn proton_caller(args: Vec<String>) -> Result<(), Error> {
 fn normal_mode(config: &Config, args: Args) -> Result<Proton, Error> {
     let common_index: Index = Index::new(&config.common())?;
 
-    let proton_path: PathBuf = match common_index.get(args.version) {
-        Some(pp) => pp,
+    let proton_path: PathBuf = match common_index.get(&args.version) {
+        Some(pp) => pp.to_path_buf(),
         None => throw!(
             Kind::ProtonMissing,
             "Proton {} does not exist",

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,8 @@ fn main() {
 fn proton_caller(args: Vec<String>) -> Result<(), Error> {
     use jargon_args::Jargon;
 
+    // args.insert(args.len(), "--index".to_string());
+
     let mut parser: Jargon = Jargon::from_vec(args);
 
     if parser.contains(["-h", "--help"]) {
@@ -104,18 +106,20 @@ fn proton_caller(args: Vec<String>) -> Result<(), Error> {
     Ok(())
 }
 
+fn get_proton_path(index: &mut Index, version: Version) -> Result<PathBuf, Error> {
+    if let Some(path) = index.get(&version) {
+        return Ok(path);
+    }
+    eprintln!("{}info:{} Proton {} not found, reindexing...", lliw::Fg::Blue, lliw::Reset, version);
+    index.index()?;
+    index.get(&version).ok_or_else(|| Error::new(Kind::ProtonMissing, format!("Proton {} does not exist", version)))
+}
+
 /// Runs caller in normal mode, running indexed Proton versions
 fn normal_mode(config: &Config, args: Args) -> Result<Proton, Error> {
-    let common_index: Index = Index::new(&config.common())?;
+    let mut index: Index = Index::new(&config.common())?;
 
-    let proton_path: PathBuf = match common_index.get(&args.version) {
-        Some(pp) => pp.to_path_buf(),
-        None => throw!(
-            Kind::ProtonMissing,
-            "Proton {} does not exist",
-            args.version
-        ),
-    };
+    let proton_path: PathBuf = get_proton_path(&mut index, args.version)?;
 
     let proton: Proton = Proton::new(
         args.version,

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,11 +1,12 @@
 use crate::{pass, throw, Error, Kind};
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::hash::Hash;
 use std::path::Path;
 use std::str::FromStr;
 
 /// Version type to handle Proton Versions
-#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub enum Version {
     /// Two number version
     Mainline(u8, u8),
@@ -66,11 +67,5 @@ impl FromStr for Version {
             [maj, min] => pass!(Version::new(maj.parse()?, min.parse()?)),
             _ => throw!(Kind::VersionParse, "'{}'", s),
         }
-    }
-}
-
-impl Hash for Version {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        core::mem::discriminant(self).hash(state);
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,5 +1,6 @@
 use crate::{pass, throw, Error, Kind};
 use std::fmt::{Display, Formatter};
+use std::hash::Hash;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -65,5 +66,11 @@ impl FromStr for Version {
             [maj, min] => pass!(Version::new(maj.parse()?, min.parse()?)),
             _ => throw!(Kind::VersionParse, "'{}'", s),
         }
+    }
+}
+
+impl Hash for Version {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        core::mem::discriminant(self).hash(state);
     }
 }


### PR DESCRIPTION
# Index

- Switched inner to be HashMap instead of BTreeMap
- Change derives to use Serde's Serialize and Deserialize.
- Added `load()`, `save()`, `cache_location()` private methods to load and save Index to index cache.
- `get()` change to handle HashMap `get()`.
- `len`, `is_empty`, and `get` were all inlined.

Overall the public API is not changed, `get()`'s returned values are not different from before.

## Version

- Version's derives updated to use Serde's Serialize and Deserialize.

## Main.rs

- `extern create` added and updates to handle changes to Indexing API

## Dependencies

toml: 0.5.8
jargon-args: 0.2.5
serde: 1.0.132
(new) bincode = "1.3.3"