### PR TITLE
Fixed typo

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -64,7 +64,7 @@ impl Config {
     pub fn config_location() -> Result<PathBuf, Error> {
         use std::env::var;
 
-        if let Ok(val) = var("XDG_CONFIG_HOEM") {
+        if let Ok(val) = var("XDG_CONFIG_HOME") {
             let path: String = format!("{}/proton.conf", val);
             return Ok(PathBuf::from(path));
         }


### PR DESCRIPTION
Was getting `proton-call: failed to open config: No such file or directory (os error 2)` error and I have the ~/.config/proton.conf file configured with my steam directory so I was looking at the code to find exactly where it was looking for a config file and found this typo so here ya go.